### PR TITLE
Fix `drs` command line client to not require `access_id`

### DIFF
--- a/ga4gh/drs/definitions/object.py
+++ b/ga4gh/drs/definitions/object.py
@@ -128,7 +128,7 @@ class DRSObject(Object):
                     valid_access_url_json = True
 
                     # issue request for the access_url if access_id provided
-                    if access_json["access_id"]:
+                    if access_json.get("access_id"):
                         kwargs = self.cli_kwargs
                         route_fetch_bytes = RouteFetchBytes(
                             kwargs["url"],


### PR DESCRIPTION
My reading of [the auth document](https://github.com/ga4gh/data-repository-service-schemas/blob/master/openapi/tags/Auth.md) suggests that `access_id` is not required, but when `access_id` is not provided by the DRS resolver, the following traceback message occurs:

```
% drs get -d https://drs.hmpdacc.org 1ZkxDLC0OEDy
...
2021-10-26 16:21:23,449 INFO    object/bundle download requested
2021-10-26 16:21:23,449 ERROR   'access_id'
Traceback (most recent call last):
  File "/Users/t/dev/ga4gh-drs-client/ga4gh/drs/cli/methods/get.py", line 113, in get
    root_object = DRSObject(root_json)
  File "/Users/t/dev/ga4gh-drs-client/ga4gh/drs/definitions/object.py", line 97, in __init__
    self.access_methods = self.__initialize_access_methods()
  File "/Users/t/dev/ga4gh-drs-client/ga4gh/drs/definitions/object.py", line 131, in __initialize_access_methods
    if access_json["access_id"]:
KeyError: 'access_id'
2021-10-26 16:21:23,451 INFO    exiting with exit code: 1
```

This PR adjusts the check into `access_json` to not require that the key exists.

With this PR, the command to retrieve public data with an HTTPS scheme succeeds:
```
% drs get -d https://drs.hmpdacc.org 1ZkxDLC0OEDy
...
2021-10-26 16:22:09,963 INFO    object/bundle download requested
2021-10-26 16:22:09,963 INFO    requested object is a single object
2021-10-26 16:22:09,964 DEBUG   1ZkxDLC0OEDy: attempting download by 'https' scheme
2021-10-26 16:22:09,964 DEBUG   1ZkxDLC0OEDy: 'https' starting download attempt by submethod __download_by_https
SRS1346527_metaphlan_bugs_list.tsv.bz2: 1it [00:00, 353.15it/s]                 
2021-10-26 16:22:10,546 DEBUG   1ZkxDLC0OEDy: 'https' finished download attempt by submethod __download_by_https. Status: COMPLETED
2021-10-26 16:22:10,547 DEBUG   1ZkxDLC0OEDy: finished download attempt by 'https' scheme. Status: COMPLETED
2021-10-26 16:22:10,547 INFO    all downloaded files written to output directory
2021-10-26 16:22:10,547 INFO    exiting with exit code: 0
```
