### PR TITLE
fix:change mkdir to makedirs. 

### DIFF
--- a/ga4gh/drs/util/data_accessor.py
+++ b/ga4gh/drs/util/data_accessor.py
@@ -165,7 +165,7 @@ class DataAccessor(object):
 
         dirname = os.path.join(self.cli_kwargs["output_dir"], self.drs_obj.id)
         if not os.path.exists(dirname):
-            os.mkdir(dirname)
+            os.makedirs(dirname)
         fname = self.drs_obj.name if self.drs_obj.name else self.drs_obj.id
         fname = os.path.basename(fname)
         if dirname:


### PR DESCRIPTION
For when using drs get -d -o .  https://gen3.biodatacatalyst.nhlbi.nih.gov/ 3e8438ec-9a7f-4215-8c23-de2c321aeb42 :
```
base) ➜  drs-client drs get -d -o .  https://gen3.biodatacatalyst.nhlbi.nih.gov/ 3e8438ec-9a7f-4215-8c23-de2c321aeb42              
2024-11-19 09:57:51,212 DEBUG   command-line arguments: {'download': True, 'output_dir': '.', 'url': 'https://gen3.biodatacatalyst.nhlbi.nih.gov/', 'object_id': '3e8438ec-9a7f-4215-8c23-de2c321aeb42', 'authtoken': 'omitted', 'expand': False, 'logfile': None, 'max_threads': 1, 'output_metadata': None, 'silent': False, 'suppress_ssl_verify': False, 'validate_checksum': False, 'verbosity': None}
2024-11-19 09:57:51,212 INFO    issuing request to DRS Object endpoint
2024-11-19 09:57:51,212 DEBUG   URL: https://gen3.biodatacatalyst.nhlbi.nih.gov//ga4gh/drs/v1/objects/3e8438ec-9a7f-4215-8c23-de2c321aeb42
2024-11-19 09:57:51,212 DEBUG   Headers: {}
2024-11-19 09:57:51,212 DEBUG   Request params: {'expand': False}
2024-11-19 09:57:52,426 INFO    JSON for object 3e8438ec-9a7f-4215-8c23-de2c321aeb42 successfully retrieved
{
    "access_methods": [
        {
            "access_id": "gs",
            "access_url": {
                "url": "gs://nih-nhlbi-biodata-catalyst-1000-genomes/CCDG_13607/Project_CCDG_13607_B01_GRM_WGS.cram.2019-02-06/Sample_HG00689/analysis/HG00689.final.cram"
            },
            "region": "",
            "type": "gs"
        },
        {
            "access_id": "s3",
            "access_url": {
                "url": "s3://nih-nhlbi-biodata-catalyst-1000-genomes-high-coverage/CCDG_13607/Project_CCDG_13607_B01_GRM_WGS.cram.2019-02-06/Sample_HG00689/analysis/HG00689.final.cram"
            },
            "region": "",
            "type": "s3"
        }
    ],
    "aliases": [],
    "checksums": [
        {
            "checksum": "340e82c8ddc017586748e04a58b85428",
            "type": "md5"
        }
    ],
    "created_time": null,
    "description": null,
    "form": "object",
    "id": "dg.4503/3e8438ec-9a7f-4215-8c23-de2c321aeb42",
    "index_created_time": "2020-01-15T16:21:03.557696",
    "index_updated_time": "2024-08-02T02:41:17.089347",
    "mime_type": "application/json",
    "name": "",
    "self_uri": "drs://dg.4503:3e8438ec-9a7f-4215-8c23-de2c321aeb42",
    "size": 26653299502,
    "updated_time": null,
    "version": null
}
2024-11-19 09:57:52,426 INFO    object/bundle download requested
2024-11-19 09:57:52,427 DEBUG   URL: https://gen3.biodatacatalyst.nhlbi.nih.gov//ga4gh/drs/v1/objects/dg.4503/3e8438ec-9a7f-4215-8c23-de2c321aeb42/access/gs
2024-11-19 09:57:52,427 DEBUG   Headers: {}
2024-11-19 09:57:52,427 DEBUG   Request params: {}
2024-11-19 09:57:53,702 DEBUG   URL: https://gen3.biodatacatalyst.nhlbi.nih.gov//ga4gh/drs/v1/objects/dg.4503/3e8438ec-9a7f-4215-8c23-de2c321aeb42/access/s3
2024-11-19 09:57:53,702 DEBUG   Headers: {}
2024-11-19 09:57:53,702 DEBUG   Request params: {}
2024-11-19 09:57:55,014 INFO    requested object is a single object
2024-11-19 09:57:55,015 DEBUG   dg.4503/3e8438ec-9a7f-4215-8c23-de2c321aeb42: attempting download by 'https' scheme
2024-11-19 09:57:55,015 DEBUG   dg.4503/3e8438ec-9a7f-4215-8c23-de2c321aeb42: 'https' starting download attempt by submethod __download_by_https
2024-11-19 09:57:55,015 INFO    all downloaded files written to output directory
2024-11-19 09:57:55,015 ERROR   [Errno 2] No such file or directory: './dg.4503/3e8438ec-9a7f-4215-8c23-de2c321aeb42'
Traceback (most recent call last):
  File "/Users/liujilong/develop/miniforge3/lib/python3.9/site-packages/ga4gh/drs/cli/methods/get.py", line 134, in get
    download_manager.write_report()
  File "/Users/liujilong/develop/miniforge3/lib/python3.9/site-packages/ga4gh/drs/util/download_manager.py", line 96, in write_report
    content.append(data_accessor.report_line())
  File "/Users/liujilong/develop/miniforge3/lib/python3.9/site-packages/ga4gh/drs/util/data_accessor.py", line 185, in report_line
    self.get_output_file_path(), # outfile
  File "/Users/liujilong/develop/miniforge3/lib/python3.9/site-packages/ga4gh/drs/util/data_accessor.py", line 168, in get_output_file_path
    os.mkdir(dirname)
FileNotFoundError: [Errno 2] No such file or directory: './dg.4503/3e8438ec-9a7f-4215-8c23-de2c321aeb42'
2024-11-19 09:57:55,018 INFO    exiting with exit code: 
```
mkdir can not create the subfolder. Change to makedirs works